### PR TITLE
E-Publish

### DIFF
--- a/src/AtolClient.php
+++ b/src/AtolClient.php
@@ -83,7 +83,9 @@ class AtolClient
         'error' => $error['text'],
         'response' => $response,
       ]);
-      throw new ClientException($error['error_id'].' - '.$error['text']);
+      if (null == $response['uuid']) {
+        throw new ClientException($error['error_id'].' - '.$error['text']);
+      }
     }
 
     return $response['uuid'];

--- a/src/AtolClient.php
+++ b/src/AtolClient.php
@@ -121,7 +121,7 @@ class AtolClient
 
   private function getToken(string $login, string $password): string
   {
-    $CACHE_KEY = 'atol.token' . $login;
+    $CACHE_KEY = 'atol.token' . str_replace('-', '_' ,$login);
     if($this->cache->has($CACHE_KEY)) {
       return (string)$this->cache->get($CACHE_KEY);
     }

--- a/src/Item.php
+++ b/src/Item.php
@@ -73,7 +73,7 @@ class Item implements RequestPart
   }
 
   /**
-   * Устанавливает наименование товара. Максимальная длина строки – 64 символа.
+   * Устанавливает наименование товара. Максимальная длина строки – 128 символов.
    *
    * @param string $name
    *
@@ -81,8 +81,8 @@ class Item implements RequestPart
    */
   public function setName(string $name): self
   {
-    if (mb_strlen($name) > 64) {
-      throw new InvalidArgumentException('Name too big. Max length size = 64');
+    if (mb_strlen($name) > 128) {
+      throw new InvalidArgumentException('Name too big. Max length size = 128');
     }
 
     $this->name = $name;

--- a/src/ReportPayload.php
+++ b/src/ReportPayload.php
@@ -44,6 +44,9 @@ class ReportPayload implements ResponsePart
   /** @var string */
   private $fnsSite;
 
+  /** @var string */
+  private $ofdReceiptUrl;
+
   /**
    * Возвращает номер чека в смене.
    *
@@ -136,6 +139,16 @@ class ReportPayload implements ResponsePart
     return $this->fnsSite;
   }
 
+  /**
+   * Возвращает URL для просмотра чека на сайте ОФД.
+   *
+   * @return string
+   */
+  public function getOfdReceiptUrl(): string
+  {
+    return $this->ofdReceiptUrl;
+  }
+
   public static function fromArray(array $array): ReportPayload
   {
     $result = new ReportPayload();
@@ -149,6 +162,7 @@ class ReportPayload implements ResponsePart
     $result->fiscalDocumentNumber = $array['fiscal_document_number'];
     $result->fiscalDocumentAttribute = $array['fiscal_document_attribute'];
     $result->fnsSite = $array['fns_site'];
+    $result->ofdReceiptUrl = $array['ofd_receipt_url'];
 
     return $result;
   }


### PR DESCRIPTION
1. Длина поля "Наименование товара" увеличена до 128 символов, согласно API
2. При формировании токена сделана замена дефисов на нижнее подчеркивание, так как при использовании в качестве кэша fileadapter возникает ошибка с недопустимым символом в имени файла.
3. В возврат RepoertPayload добавлен URL на сайт ОФД для проверки чека
4. При вызове метода setReceipt для чека, который уже зарегистрирован, вместо ошибки возвращается uuid